### PR TITLE
:sparkles: Return PlantUML server URL instead of image data

### DIFF
--- a/api/plantuml.ts
+++ b/api/plantuml.ts
@@ -1,6 +1,7 @@
 import { createHash } from "../src/deps.ts";
 import { ServerRequest } from "../src/deps_pinned.ts";
-import { fetchImage, fetchText, respondImage } from "../src/fetch.ts";
+import { fetchText } from "../src/fetch.ts";
+import { toPlantUMLURL } from "../src/toPlantUMLURL.ts";
 
 export default async (req: ServerRequest) => {
   const base = `${req.headers.get("x-forwarded-proto")}://${
@@ -40,9 +41,15 @@ export default async (req: ServerRequest) => {
       req.respond({ status: 304 });
       return;
     }
-    const imageData = await fetchImage(text, imageType);
-    const buffer = new Uint8Array(await imageData.arrayBuffer());
-    respondImage(buffer, imageData.type, req, { eTag });
+
+    const headers = new Headers();
+    const path = toPlantUMLURL(text, imageType);
+    console.log(`Go to "${path}"`);
+    headers.set("location", path);
+    req.respond({
+      status: 301,
+      headers,
+    });
   } catch (e) {
     req.respond({ status: 400, body: e.message });
   }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,8 +1,3 @@
-import { deflate } from "./deps.ts";
-import { ServerRequest } from "./deps_pinned.ts";
-import { encode64 } from "./encoder.ts";
-import { textToBuffer } from "./converter.ts";
-
 export async function fetchText(url: string) {
   const response = await fetch(url);
 
@@ -14,34 +9,4 @@ export async function fetchText(url: string) {
     throw new Error(`Text is empty`);
   }
   return text;
-}
-
-export async function fetchImage(text: string, imageType: "png" | "svg") {
-  const response = await fetch(
-    `http://www.plantuml.com/plantuml/${imageType}/${
-      encode64(deflate(textToBuffer(text), 9))
-    }`,
-  );
-  if (!response.ok) {
-    throw new Error(
-      "Failed to fetch a plantUML image from the PlantUML server",
-    );
-  }
-  return await response.blob();
-}
-
-export function respondImage(
-  imageData: Uint8Array,
-  mimeType: string,
-  req: ServerRequest,
-  options: { eTag: string },
-) {
-  const headers = new Headers();
-  headers.set("Content-Type", `${mimeType}; charaset=utf-8`);
-  headers.set("Cache-Control", "private, max-age=0");
-  headers.set("ETag", options.eTag);
-  req.respond({
-    headers,
-    body: imageData,
-  });
 }

--- a/src/toPlantUMLURL.ts
+++ b/src/toPlantUMLURL.ts
@@ -1,0 +1,8 @@
+import { deflate } from "./deps.ts";
+import { encode64 } from "./encoder.ts";
+import { textToBuffer } from "./converter.ts";
+
+export const toPlantUMLURL = (uml: string, imageType: "png" | "svg") =>
+  `http://www.plantuml.com/plantuml/${imageType}/${
+    encode64(deflate(textToBuffer(uml), 9))
+  }`;

--- a/src/toPlantUMLURL.ts
+++ b/src/toPlantUMLURL.ts
@@ -3,6 +3,6 @@ import { encode64 } from "./encoder.ts";
 import { textToBuffer } from "./converter.ts";
 
 export const toPlantUMLURL = (uml: string, imageType: "png" | "svg") =>
-  `http://www.plantuml.com/plantuml/${imageType}/${
+  `https://www.plantuml.com/plantuml/${imageType}/${
     encode64(deflate(textToBuffer(uml), 9))
   }`;


### PR DESCRIPTION
close [⬜PlantUML serverのURLにredirectする](https://scrapbox.io/takker/⬜PlantUML_serverのURLにredirectする)